### PR TITLE
Family misspelled

### DIFF
--- a/_episodes/03-dates-as-data.md
+++ b/_episodes/03-dates-as-data.md
@@ -36,7 +36,7 @@ and stores the dates may be problematic.
 In particular, please remember that functions that are valid for a given
 spreadsheet program (be it LibreOffice, Microsoft Excel, OpenOffice.org,
 Gnumeric, etc.) are usually guaranteed to be compatible only within the same
-famly of products. If you will later need to export the data and need to
+family of products. If you will later need to export the data and need to
 conserve the timestamps you are better off handling them using custom solutions.
 
 Let's try with a simple challenge.


### PR DESCRIPTION
The word family is misspelled here.

