### PR TITLE
change heading to display lists with correct font size

### DIFF
--- a/episodes/03-dates-as-data.md
+++ b/episodes/03-dates-as-data.md
@@ -255,17 +255,17 @@ This practice will make your data less ambiguous, will guard
 against changes that may be caused if the spreadsheet is opened by other software,
 and generally make your data table more accessible and interoperable.
 
-## Resources
+## Further Resources
 
 Working with dates and day of year information can be unfamiliar since it does not match how we typically see dates on a calendar by the day of a month. These resources provide useful information for calculating the day of the year:
 
-- The Earth Systems Research Lab provides this calendar that displays day of year information for any year you select: [https://www.esrl.noaa.gov/gmd/grad/neubrew/Calendar.jsp](https://www.esrl.noaa.gov/gmd/grad/neubrew/Calendar.jsp)
-- The U.S. National Snow and Ice Data Center provides a useful chart to calculate the day of year: [https://nsidc.org/support/faq/day-year-doy-calendar](https://nsidc.org/support/faq/day-year-doy-calendar)
+- The Earth Systems Research Lab provides this calendar that displays day of year information for any year you select: [https://www.esrl.noaa.gov/gmd/grad/neubrew/Calendar.jsp](https://www.esrl.noaa.gov/gmd/grad/neubrew/Calendar.jsp).
+- The U.S. National Snow and Ice Data Center provides a useful chart to calculate the day of year: [https://nsidc.org/support/faq/day-year-doy-calendar](https://nsidc.org/support/faq/day-year-doy-calendar).
 
 Most spreadsheet applications offer more detailed information about working with date and time information. Some of these are referenced below:
 
-- Microsoft Excel [date and time functions reference](https://support.microsoft.com/en-us/office/date-and-time-functions-reference-fd1b5961-c1ae-4677-be58-074152f97b81)
-- LibreOffice Date \& Time Functions Reference [v. 6.2](https://help.libreoffice.org/6.2/en-US/text/scalc/01/04060102.html)
+- Microsoft Excel [date and time functions reference](https://support.microsoft.com/en-us/office/date-and-time-functions-reference-fd1b5961-c1ae-4677-be58-074152f97b81).
+- LibreOffice Date \& Time Functions Reference [v. 6.2](https://help.libreoffice.org/6.2/en-US/text/scalc/01/04060102.html).
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
This change is in response to issue #143 to correct the display of fonts in <ul> elements at the regular size. Note: heading "Resources" invokes a different CSS rule. 