### PR TITLE
Minor copyedit to introductory paragraph

### DIFF
--- a/index.md
+++ b/index.md
@@ -19,7 +19,7 @@ status: Teaching
 site: sandpaper::sandpaper_site
 ---
 
-[Library Carpentry](https://librarycarpentry.org/) aims to teach librarians, information professionals, and researchers basic concepts, skills, and tools for working with data so that they can get more done in less time, and with less pain. This lesson was designed for those interested in working with Library Carpentry data in spreadsheets.
+[Library Carpentry](https://librarycarpentry.org/) aims to teach librarians, information professionals, and researchers basic concepts, skills, and tools for working with data so that they can get more done in less time, and with less pain. This lesson was designed to teach the principles of working with data in spreadsheets.
 
 ::::::::::::::::::::::::::::::::::::::::::  prereq
 


### PR DESCRIPTION
I updated the statement in the introductory paragraph on the index page of this lesson because I thought the phrasing was incorrect. The original sentence said that the purpose of the lesson was to teach people interested in using "Library Carpentry data in spreadsheets." I do not think the intended audience for the lesson is people wanting to work with "Library Carpentry data." I think it was an unintentional error, and I hope my revision clarifies what the purpose of the lesson is.  
