### PR TITLE
add jargon busting exercise

### DIFF
--- a/episodes/00-intro.md
+++ b/episodes/00-intro.md
@@ -52,6 +52,7 @@ contributors:
   of the data in the spreadsheet. What are the pain points!?
 - As people answer highlight some of these issues with spreadsheets
 
+
 :::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Good **data organization** is the foundation of much of our day-to-day
@@ -69,7 +70,16 @@ to be able to do as librarians. We can use them for:
 - Statistics
 - Plotting
 
-***
+:::::::::::::::::::::::::::::::::::::::::  callout
+
+## Jargon busting (Optional, not included in timing)
+The [Jargon Busting exercise](jargon_busting.md) is a helpful way to begin to explore terms, phrases, and ideas related to code and software development.
+
+:::::::::::::::::::::::::::::::::::::::: instructor
+This exercise can be useful when you teach Tidy Data as the introduction to a full LC workshop, especially if you want learners to have an opportunity to meet each other and interact. It can take anywhere from 10 to 45 minutes, depending on your approach.
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ### Spreadsheet outline
 
@@ -193,6 +203,7 @@ In this lesson, we're going to talk about:
 4. [Basic quality control and data manipulation in spreadsheets](04-quality-control.md)
 5. [Exporting data from spreadsheets](05-exporting-data.md)
 6. [Data export formats caveats](06-data-formats-caveats.md)
+
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/learners/jargon_busting.md
+++ b/learners/jargon_busting.md
@@ -1,0 +1,44 @@
+---
+title: Jargon Busting
+teaching: 5
+exercises: 30
+---
+
+::::::::::::::::::::::::::::::::::::::: objectives
+
+- Explain terms, phrases, and concepts associated with software development in libraries.
+- Compare knowledge of these terms, phrases, and concepts.
+- Differentiate between these terms, phrases, and concepts.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::: questions
+
+- What terms, phrases, or ideas around code, data, or software development have you come across and feel you should know better?
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::  challenge
+
+## Jargon Busting
+
+This exercise is an opportunity to gain a firmer grasp on some concepts related to data, code or software development in libraries.
+
+1. Pair with a neighbor or small group and decide who will take notes.
+2. Talk for three to five minutes about any terms, phrases, or ideas related to code, data, or software development that you've come across and perhaps feel you should know better.
+3. Have the note-taker compile your list of problematic terms, phrases, and ideas.
+4. Now in a larger group (or with everyone in the workshop) spend 5 to 10 minutes working together to try to explain what some of those terms, phrases, or ideas on your list mean. You can use other people in the room/Zoom, the Carpentries' Glosario below, and other internet research to learn more about the terms.
+5. The instructor will collate terms and explanations on a whiteboard or Etherpad and facilitate a discussion about what we will cover today and where you can go for help on things we won't cover. 
+
+### [Carpentries Glosario (English)](https://glosario.carpentries.org/en/)
+While there's not a single site that will include *every* term that workshop attendees bring to the table, the Carpentries' glossary is a great starting place for computing and data science terms. [Glosario includes multilingual glossaries](https://glosario.carpentries.org/), as well.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+
+:::::::::::::::::::::::::::::::::::::::: keypoints
+
+- It helps to share what you know and don't know about software development and data science jargon.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+


### PR DESCRIPTION
- Adds an optional episode, jargon_busting.md, to the learners/ directory 
- This optional Jargon Busting episode comes from the LC Overview lesson, but was edited here for clarity and to highlight Glosario.
- Adds a callout in the Using spreadsheet programs episode to point to the Jargon Busting episode
- Includes instructor notes that Jargon Busting is an optional exercise for learners in Tidy Data

This is step one to resolve an [issue in the LC overview repo](https://github.com/LibraryCarpentry/lc-overview/issues/59) that aims to move the Jargon Busting episode from LC Overview to other LC lessons that could serve as introductions to full LC core workshops. The episode will also be added to the new [Introduction to Computational Thinking lesson](https://github.com/LibraryCarpentry/lc-computational-thinking). The decision was made in collaboration with @LibraryCarpentry/curriculum-advisors.
