### PR TITLE
Update 03-dates-as-data.md to update link to Microsoft's explanation of Excel dates

### DIFF
--- a/episodes/03-dates-as-data.md
+++ b/episodes/03-dates-as-data.md
@@ -109,7 +109,7 @@ from before and after this date, Excel will translate only the post-1900 dates i
 If you're working with historic data, be extremely careful with your dates!
 
 Excel also entertains a second date system, the 1904 date system, as the default in Excel for Macintosh. This system will assign a
-different serial number than the [1900 date system](https://support.microsoft.com/en-us/help/214330/differences-between-the-1900-and-the-1904-date-system-in-excel). Because of this,
+different serial number than the [1900 date system](https://support.microsoft.com/en-us/office/date-systems-in-excel-e7fe7167-48a9-4b96-bb53-5612a800b487). Because of this,
 [dates must be checked for accuracy when exporting data from Excel](https://uc3.cdlib.org/2014/04/09/abandon-all-hope-ye-who-enter-dates-in-excel/) (look for dates that are about 4 years off).
 
 


### PR DESCRIPTION
updating the link for Microsoft's explanation of Excel's date systems

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
$170

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
Issue reported states that link explaining the 1900 date system is broken. I located the correct link, [morskyjezek](https://github.com/morskyjezek) agrees it is the correct link. This pull request updates the link in the lesson to the new link.

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
